### PR TITLE
Govway api

### DIFF
--- a/gateways/govway/README.md
+++ b/gateways/govway/README.md
@@ -1,16 +1,7 @@
 # GovWay
 
-GovWay è un API gateway open source (licenza GPL-v3) progettato per le specifiche esigenze della Pubblica Amministrazione. Basato sull’esperienza del progetto OpenSPCoop e della Porta di Dominio italiana, assicura la conformità alle normative dell'interoperabilità italiana ed europea, in maniera completamente trasparente alle applicazioni.
-* Conforme alle nuove linee guida AGID per l’interoperabilità ModI 2018 (profilo API Gateway)
-* Conforme alle specifiche per l’interoperabilità europea tramite l’utilizzo del "building block" eDelivery del progetto europeo CEF (Connecting European Facilities) (profilo eDelivery)
-* Conforme alle specifiche per la fatturazione elettronica sul canale SdiCoop (profilo Fatturazione Elettronica)
-* Retrocompatibile con il paradigma di cooperazione applicativa (profilo SPCoop) 
+[GovWay](https://github.com/link-it/govway) è un API gateway open source (licenza GPL-v3) basato su [OpenSPCoop](https://www.openspcoop.org/openspcoop/) e della Porta di Dominio italiana.
 
-Sito Web: https://govway.org
-
-Pagina GitHub: https://github.com/link-it/govway
-
-Licenza: GPL-v3
 
 ## Conformità al Modello di Interoperabilità 2018
 * API REST

--- a/gateways/govway/README.md
+++ b/gateways/govway/README.md
@@ -39,8 +39,8 @@ Di seguito alcune delle funzionalità indicate nella documentazione di Govway a 
 	- Signed JWT with Client Secret: modalità di negoziazione identica alla precedente dove però l’asserzione JWT viene firmata tramite una chiave simmetrica.
 
 * [API](https://govway.readthedocs.io/it/latest/api/index.html) di configurazione e monitoraggio del gateway OpenAPI 3.0
-  - [API di Configurazione](https://generator.swagger.io/?url=https://raw.githubusercontent.com/link-it/govway/master/tools/rs/config/server/src/schemi/merge/govway_rs-api_config.yaml)
-  - [API di Monitoraggio](https://generator.swagger.io/?url=https://raw.githubusercontent.com/link-it/govway/master/tools/rs/monitor/server/src/schemi/merge/govway_rs-api_monitor.yaml)
+  - [API di Configurazione](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/link-it/govway/master/tools/rs/config/server/src/schemi/merge/govway_rs-api_config.yaml)
+  - [API di Monitoraggio](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/link-it/govway/master/tools/rs/monitor/server/src/schemi/merge/govway_rs-api_monitor.yaml)
 
 * Possibilità di realizzare API REST per i servizi SOAP preesistenti in accordo a template di conversione attraverso [engine di trasformazione](https://govway.readthedocs.io/it/latest/console/profiloApiGateway/trasformazioni/index.html)
 

--- a/gateways/govway/README.md
+++ b/gateways/govway/README.md
@@ -3,7 +3,7 @@
 [GovWay](https://github.com/link-it/govway) è un API gateway open source (licenza GPL-v3) basato su [OpenSPCoop](https://www.openspcoop.org/openspcoop/) - implementazione della Porta di Dominio italiana.
 
 
-## Conformità al Modello di Interoperabilità 2018
+## Funzionalità del Modello di Interoperabilità 2018 implementate
 * API REST
   - Interfacce: supporto per il caricamento di API OpenAPI 3.0.
   - Validazione: supporto per la validazione dei contenuti in formato JSON ed XML

--- a/gateways/govway/README.md
+++ b/gateways/govway/README.md
@@ -1,0 +1,51 @@
+# GovWay
+
+GovWay è un API gateway open source (licenza GPL-v3) progettato per le specifiche esigenze della Pubblica Amministrazione. Basato sull’esperienza del progetto OpenSPCoop e della Porta di Dominio italiana, assicura la conformità alle normative dell'interoperabilità italiana ed europea, in maniera completamente trasparente alle applicazioni.
+* Conforme alle nuove linee guida AGID per l’interoperabilità ModI 2018 (profilo API Gateway)
+* Conforme alle specifiche per l’interoperabilità europea tramite l’utilizzo del "building block" eDelivery del progetto europeo CEF (Connecting European Facilities) (profilo eDelivery)
+* Conforme alle specifiche per la fatturazione elettronica sul canale SdiCoop (profilo Fatturazione Elettronica)
+* Retrocompatibile con il paradigma di cooperazione applicativa (profilo SPCoop) 
+
+Sito Web: https://govway.org
+Pagina GitHub: https://github.com/link-it/govway
+Licenza: GPL-v3
+
+## Conformità al Modello di Interoperabilità 2018
+* API REST
+  - Interfacce: supporto per il caricamento di API OpenAPI 3.0.
+  - Validazione: supporto per la validazione dei contenuti in formato JSON ed XML
+  - Sicurezza: supporto del formato JOSE per la firma e la crittografia in ambito JSON e XmlSignature ed XmlEncrypt in ambito XML.
+  - Error Handling: conforme alle specifiche del RFC 7807 (Problem Details for HTTP APIs).
+* Web Services SOAP
+  - Interfacce: supporto per il caricamento di interfacce WSDL.
+  - Validazione: supporto per la validazione dei contenuti in formato SOAP 1.1 e 1.2. 
+  - Sicurezza: supportate tutte le funzionalità del protocollo WSSecurity (Encrypt, Signature, Timestamp, SAML, UsernameToken, ...).
+  - MTOM: supportato sia in maniera trasparente dal Gateway che con la possibilità di delegargli le fasi di imbustamento o sbustamento.
+  - Error Handling: generazione di SOAPFault, con detail mutuato da RFC 7807.
+* Autenticazione ed Autorizzazione
+  - Protocollo HTTPS: supporto della mutua autenticazione su HTTPS, autorizzazione basata sui dati del certificato X509 del mittente.
+  - Protocollo OAuth2/OIDC: supporto della validazione dei token OAuth2 ricevuti (anche tramite Introspection), autorizzazione basata sui claims estratti dal token (es. Scope).
+  - Protocollo SAML: supporto della validazione di Asserzioni SAML (v1 e v2).
+  - Protocollo XACML: supporto di XACML per realizzare policy di autorizzazione complesse.
+* Throttling
+  - Rate Limiting: possibilità di attuare politiche di Rate Limiting basate su soglie relative al numero di richieste, ai tempi di risposta e all'occupazione di banda
+  - Gestione degli header HTTP:
+    - X-RateLimit-Limit: limite massimo di richieste;
+    - X-RateLimit-Remaining: numero di richieste rimanenti fino al prossimo reset;
+    - X-RateLimit-Reset: il numero di secondi mancanti al momento in cui il limite verrà reimpostato
+  - Error Handling: in caso di violazione viene generato un response code http 429
+  - Sospensione di una API: possibilità di sospendere l’accesso a una API o di limitare l’accesso ad API temporaneamente non disponibili (es. read timeout), generando un response code http 503, con header ‘Retry-After’ valorizzato al numero di secondi di attesa richiesti al client.
+* Tracciamento
+  - Ogni richiesta viene tracciata, indipendentemente dal livello di logging o dall’esito della richiesta
+  - Per ogni richiesta vengono tracciate tutte le informazioni richieste dal ModI2018:
+    - identificazione della richiesta: data e ora della richiesta, dell’erogatore e dell’API richiesta (url invocazione, http method per REST, soap action per SOAP).
+    - esito della chiamata: http status code, eventuali fault (SOAPFault per SOAP,  Problem Details per REST), esito della transazione.
+    - identificazione del richiedente: identificazione del soggetto fruitore, Identificativo dell’applicativo chiamante se disponibile, indirizzo IP del Chiamante.
+    - correlazione alla transazione applicativa: possibilità di estrarre dai contenuti della richiesta ed associare alla traccia un identificativo applicativo univoco. Possibilità di correlare le tracce di chiamate diverse tramite un identificativo unico di correlazione.
+* Work In Progress
+  - API di configurazione e monitoraggio del gateway OpenAPI 3.0, conformi alle linee guida del ModI 2018, riusando i componenti definiti in: 
+    - https://github.com/teamdigitale/openapi/blob/master/docs/definitions.yaml
+  - Supporto ‘Alternative Schema’ per effettuare validazione tramite OpenAPI 3.0 utilizzando schemi differenti come XSD Schema o JSON Schema.  
+    - https://github.com/teamdigitale/api-openapi-samples/blob/alternativeSchema/openapi-v3/external-schema.yaml
+    - https://github.com/OAI/OpenAPI-Specification/pull/1736/files#r248600075
+  - API REST per i servizi SOAP preesistenti in accordo a template di conversione.

--- a/gateways/govway/README.md
+++ b/gateways/govway/README.md
@@ -35,7 +35,10 @@
     - esito della chiamata: http status code, eventuali fault (SOAPFault per SOAP,  Problem Details per REST), esito della transazione.
     - identificazione del richiedente: identificazione del soggetto fruitore, Identificativo dell’applicativo chiamante se disponibile, indirizzo IP del Chiamante.
     - correlazione alla transazione applicativa: possibilità di estrarre dai contenuti della richiesta ed associare alla traccia un identificativo applicativo univoco. Possibilità di correlare le tracce di chiamate diverse tramite un identificativo unico di correlazione.
-* Work In Progress
+
+
+## Da implementare / Work In Progress
+
   - API di configurazione e monitoraggio del gateway OpenAPI 3.0, conformi alle linee guida del ModI 2018, riusando i componenti definiti in: 
     - https://github.com/teamdigitale/openapi/blob/master/docs/definitions.yaml
   - Supporto ‘Alternative Schema’ per effettuare validazione tramite OpenAPI 3.0 utilizzando schemi differenti come XSD Schema o JSON Schema.  

--- a/gateways/govway/README.md
+++ b/gateways/govway/README.md
@@ -1,6 +1,6 @@
 # GovWay
 
-[GovWay](https://github.com/link-it/govway) è un API gateway open source (licenza GPL-v3) basato su [OpenSPCoop](https://www.openspcoop.org/openspcoop/) e della Porta di Dominio italiana.
+[GovWay](https://github.com/link-it/govway) è un API gateway open source (licenza GPL-v3) basato su [OpenSPCoop](https://www.openspcoop.org/openspcoop/) - implementazione della Porta di Dominio italiana.
 
 
 ## Conformità al Modello di Interoperabilità 2018

--- a/gateways/govway/README.md
+++ b/gateways/govway/README.md
@@ -7,14 +7,16 @@ GovWay è un API gateway open source (licenza GPL-v3) progettato per le specific
 * Retrocompatibile con il paradigma di cooperazione applicativa (profilo SPCoop) 
 
 Sito Web: https://govway.org
+
 Pagina GitHub: https://github.com/link-it/govway
+
 Licenza: GPL-v3
 
 ## Conformità al Modello di Interoperabilità 2018
 * API REST
   - Interfacce: supporto per il caricamento di API OpenAPI 3.0.
   - Validazione: supporto per la validazione dei contenuti in formato JSON ed XML
-  - Sicurezza: supporto del formato JOSE per la firma e la crittografia in ambito JSON e XmlSignature ed XmlEncrypt in ambito XML.
+  - Sicurezza: supporto del formato JOSE per la firma e la crittografia in ambito JSON e XmlSignature/XmlEncrypt in ambito XML.
   - Error Handling: conforme alle specifiche del RFC 7807 (Problem Details for HTTP APIs).
 * Web Services SOAP
   - Interfacce: supporto per il caricamento di interfacce WSDL.
@@ -33,7 +35,7 @@ Licenza: GPL-v3
     - X-RateLimit-Limit: limite massimo di richieste;
     - X-RateLimit-Remaining: numero di richieste rimanenti fino al prossimo reset;
     - X-RateLimit-Reset: il numero di secondi mancanti al momento in cui il limite verrà reimpostato
-  - Error Handling: in caso di violazione viene generato un response code http 429
+  - Error Handling: in caso di violazione viene generato un response code http 429 (con Problem Details RFC 7807)
   - Sospensione di una API: possibilità di sospendere l’accesso a una API o di limitare l’accesso ad API temporaneamente non disponibili (es. read timeout), generando un response code http 503, con header ‘Retry-After’ valorizzato al numero di secondi di attesa richiesti al client.
 * Tracciamento
   - Ogni richiesta viene tracciata, indipendentemente dal livello di logging o dall’esito della richiesta

--- a/gateways/govway/README.md
+++ b/gateways/govway/README.md
@@ -1,36 +1,25 @@
 # GovWay
 
-[GovWay](https://github.com/link-it/govway) è un API gateway open source (licenza GPL-v3) basato su [OpenSPCoop](https://www.openspcoop.org/openspcoop/) - implementazione della Porta di Dominio italiana.
+[GovWay](https://github.com/link-it/govway) è un API gateway open source (licenza GPL-v3) prodotto da link.it e basato sull'implementazione della Porta di Dominio [OpenSPCoop](https://www.openspcoop.org/openspcoop/).
 
+Di seguito alcune delle funzionalità indicate nella documentazione di Govway a supporto del ModI2018.
 
-## Funzionalità del Modello di Interoperabilità 2018 implementate
+## Funzionalità REST implementate
 * API REST
-  - Interfacce: supporto per il caricamento di API OpenAPI 3.0.
-  - Validazione: supporto per la validazione dei contenuti in formato JSON ed XML
-  - Sicurezza: supporto del formato JOSE per la firma e la crittografia in ambito JSON e XmlSignature/XmlEncrypt in ambito XML.
+  - Interfacce: caricamento di API OpenAPI 3.0.
   - Error Handling: conforme alle specifiche del RFC 7807 (Problem Details for HTTP APIs).
-* Web Services SOAP
-  - Interfacce: supporto per il caricamento di interfacce WSDL.
-  - Validazione: supporto per la validazione dei contenuti in formato SOAP 1.1 e 1.2. 
-  - Sicurezza: supportate tutte le funzionalità del protocollo WSSecurity (Encrypt, Signature, Timestamp, SAML, UsernameToken, ...).
-  - MTOM: supportato sia in maniera trasparente dal Gateway che con la possibilità di delegargli le fasi di imbustamento o sbustamento.
-  - Error Handling: generazione di SOAPFault, con detail mutuato da RFC 7807.
-* Autenticazione ed Autorizzazione
-  - Protocollo HTTPS: supporto della mutua autenticazione su HTTPS, autorizzazione basata sui dati del certificato X509 del mittente.
-  - Protocollo OAuth2/OIDC: supporto della validazione dei token OAuth2 ricevuti (anche tramite Introspection), autorizzazione basata sui claims estratti dal token (es. Scope).
-  - Protocollo SAML: supporto della validazione di Asserzioni SAML (v1 e v2).
-  - Protocollo XACML: supporto di XACML per realizzare policy di autorizzazione complesse.
+
 * Throttling
-  - Rate Limiting: possibilità di attuare politiche di Rate Limiting basate su soglie relative al numero di richieste, ai tempi di risposta e all'occupazione di banda
-  - Gestione degli header HTTP:
+  - Gestione degli header di throttling:
     - X-RateLimit-Limit: limite massimo di richieste;
     - X-RateLimit-Remaining: numero di richieste rimanenti fino al prossimo reset;
     - X-RateLimit-Reset: il numero di secondi mancanti al momento in cui il limite verrà reimpostato
-  - Error Handling: in caso di violazione viene generato un response code http 429 (con Problem Details RFC 7807)
+  - In caso di violazione viene generato un response code HTTP 429 (con Problem Details RFC 7807)
   - Sospensione di una API: possibilità di sospendere l’accesso a una API o di limitare l’accesso ad API temporaneamente non disponibili (es. read timeout), generando un response code http 503, con header ‘Retry-After’ valorizzato al numero di secondi di attesa richiesti al client.
+  
 * Tracciamento
   - Ogni richiesta viene tracciata, indipendentemente dal livello di logging o dall’esito della richiesta
-  - Per ogni richiesta vengono tracciate tutte le informazioni richieste dal ModI2018:
+  - Campi tracciati:
     - identificazione della richiesta: data e ora della richiesta, dell’erogatore e dell’API richiesta (url invocazione, http method per REST, soap action per SOAP).
     - esito della chiamata: http status code, eventuali fault (SOAPFault per SOAP,  Problem Details per REST), esito della transazione.
     - identificazione del richiedente: identificazione del soggetto fruitore, Identificativo dell’applicativo chiamante se disponibile, indirizzo IP del Chiamante.


### PR DESCRIPTION
Sostituito il visualizzatore delle API di configurazione e monitoraggio da 'generator.swagger.io' a 'redocly.github.io' per sopperire al fatto che lo swagger generator non consente più di indicare l'openapi da visualizzare tramite il parametro 'url'.